### PR TITLE
fix: add separators for persian

### DIFF
--- a/numberFormatter.node.js
+++ b/numberFormatter.node.js
@@ -32,35 +32,31 @@ const customSeperatorFormats = {
         return formatNumberWithSeperators(number, '', ',');
     },
     persian: function (number) {
-        // Thousands separator: ,
-        // Decimal separator: /
-        const persianArray = ['۰', '۱', '۲', '۳', '۴', '۵', '۶', '۷', '۸', '۹', '،'];
-        let outputStr = '';
+        const nums = {
+            0: '۰',
+            1: '۱',
+            2: '۲',
+            3: '۳',
+            4: '۴',
+            5: '۵',
+            6: '۶',
+            7: '۷',
+            8: '۸',
+            9: '۹'
+        };
 
-        const numStr = number.toString();
+        // use dot for decimal separator
+        // in Persian decimal separated can be like <sub>/</sub>
+        // but '.' is used to avoid html/formatting
+        const numStr = formatNumberWithSeperators(number, ',', '.').toString();
+        const arrNum = numStr.toString().split('').map((ch) => {
+            if (ch === '.' || ch === ',' || ch === '-') {
+                return ch;
+            }
+            return nums[Number(ch)];
+        });
 
-        for (let i = 0; i < numStr.length; i++) {
-            // for some reason . and - got caught up in the lower conditions
-            // and failed in a previous project.
-            if (numStr[i] === '.') {
-                outputStr += '.';
-            }
-            else if (numStr[i] === '-') {
-                outputStr += '-';
-            }
-            else if (!Number.isNaN(numStr[i])) {
-                outputStr += persianArray[numStr[i]];
-            }
-            else if (numStr[i] === ',') {
-                outputStr += persianArray[10];
-            }
-            else {
-                // try and catch other non-number characters.
-                outputStr += numStr[i];
-            }
-        }
-
-        return outputStr;
+        return arrNum.join('');
     },
     nepali: function (number) {
         const nums = {
@@ -78,13 +74,13 @@ const customSeperatorFormats = {
 
         const numStr = formatNumberWithSeperators(number, ',', '.').toString();
 
-        const arrNumNe = numStr.toString().split('').map((ch) => {
+        const arrNum = numStr.toString().split('').map((ch) => {
             if (ch === '.' || ch === ',') {
                 return ch;
             }
             return nums[Number(ch)];
         });
-        return arrNumNe.join('');
+        return arrNum.join('');
     },
     hindi: function (number) {
         const splitNumber = getIntegerAndFractional(number);
@@ -118,13 +114,13 @@ const customSeperatorFormats = {
 
         const numStr = formatNumberWithSeperators(number, ',', '.').toString();
 
-        const arrNumNe = numStr.toString().split('').map((ch) => {
+        const arrNum = numStr.toString().split('').map((ch) => {
             if (ch === '.' || ch === ',') {
                 return ch;
             }
             return nums[Number(ch)];
         });
-        return arrNumNe.join('');
+        return arrNum.join('');
     },
     pashto: function (number) {
         const nums = {
@@ -141,14 +137,14 @@ const customSeperatorFormats = {
         };
 
         const numStr = formatNumberWithSeperators(number, ',', '.').toString();
-        const arrNumNe = numStr.toString().split('').map((ch) => {
+        const arrNum = numStr.toString().split('').map((ch) => {
             if (ch === '.' || ch === ',') {
                 return ch;
             }
             return nums[Number(ch)];
         });
 
-        return arrNumNe.join('');
+        return arrNum.join('');
     },
 };
 

--- a/tests/numberFormatter.spec.js
+++ b/tests/numberFormatter.spec.js
@@ -164,12 +164,12 @@ describe('Number formatter', function () {
     });
 
     it('should format numbers using the BBC Persian style', function () {
-        expect(NumberFormatter.format('persian', 14562.65)).toBe('۱۴۵۶۲.۶۵');
+        expect(NumberFormatter.format('persian', 14562.65)).toBe('۱۴,۵۶۲.۶۵');
         expect(NumberFormatter.format('persian', 546)).toBe('۵۴۶');
-        expect(NumberFormatter.format('persian', 123456)).toBe('۱۲۳۴۵۶');
+        expect(NumberFormatter.format('persian', 123456)).toBe('۱۲۳,۴۵۶');
         expect(NumberFormatter.format('persian', 1.23)).toBe('۱.۲۳');
-        expect(NumberFormatter.format('persian', 1234567)).toBe('۱۲۳۴۵۶۷');
-        expect(NumberFormatter.format('persian', 100000000)).toBe('۱۰۰۰۰۰۰۰۰');
+        expect(NumberFormatter.format('persian', 1234567)).toBe('۱,۲۳۴,۵۶۷');
+        expect(NumberFormatter.format('persian', 100000000)).toBe('۱۰۰,۰۰۰,۰۰۰');
     });
 
     it('should format numbers using the BBC Portuguese style', function () {


### PR DESCRIPTION
# Changes
- use comma and decimal separators for persian
   uses same logic as nepali/pashto/other languages for formatting
   updates array naming to match for all langs (was arrayNumNe - Ne for nepali?).


# out of scope 
- reducing duplication - could refactor nepali/pashto etc to reduce code duplication